### PR TITLE
Limit volcano climatology message to root CPU

### DIFF
--- a/src/Extensions/hcox_volcano_mod.F90
+++ b/src/Extensions/hcox_volcano_mod.F90
@@ -651,9 +651,11 @@ CONTAINS
           INQUIRE( FILE=TRIM( ThisFile ), EXIST=FileExists )
 
           ! Write message to stdout and HEMCO log
-          MSG = 'Attempting to read volcano climatology file'
-          WRITE( 6,   300 ) TRIM( MSG )             
-          CALL HCO_MSG( HcoState%Config%Err, MSG )
+          IF ( Hcostate%amIRoot ) THEN
+             MSG = 'Attempting to read volcano climatology file'
+             WRITE( 6,   300 ) TRIM( MSG )             
+             CALL HCO_MSG( HcoState%Config%Err, MSG )
+          ENDIF
 
           ! Create a display string based on whether or not the file is found
           IF ( FileExists ) THEN


### PR DESCRIPTION
Prevent excessive messages in log file if the volcano climatology is being used.

### Name and Institution (Required)

Name: Christoph Keller
Institution: NASA GMAO / MSU

### Confirm you have reviewed the following documentation

- [x ] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update
Bug fix that limits the warning message about using climatological volcano emissions to the root CPU. 

### Expected changes
Zero diff

### Reference(s)
N/A

### Related Github Issue(s)
N/A
