### PR TITLE
Removed the local sumdomain checks if a variable has been filled from a GEOS restart

### DIFF
--- a/src/Core/hco_restart_mod.F90
+++ b/src/Core/hco_restart_mod.F90
@@ -313,10 +313,14 @@ CONTAINS
                                   1,        FLD,      RC, Arr3D=Arr3D )
     IF ( RC /= HCO_SUCCESS ) RETURN
 
+#if defined( MODEL_GEOS )
+    ! No further "local" checks are needed for GEOS
+#else
     ! If field is all zero assume it to be not filled
     IF ( FLD ) THEN
        IF ( SUM(Arr3D) == 0.0 ) FLD = .FALSE.
     ENDIF
+#endif
 
     ! Log output
     IF ( HCO_IsVerb(HcoState%Config%Err,1) ) THEN
@@ -467,10 +471,14 @@ CONTAINS
                                   1,        FLD,      RC, Arr2D=Arr2D )
     IF ( RC /= HCO_SUCCESS ) RETURN
 
+#if defined( MODEL_GEOS )
+    ! No further "local" checks are needed for GEOS
+#else
     ! If field is all zero assume it to be not filled
     IF ( FLD ) THEN
        IF ( SUM(Arr2D) == 0.0 ) FLD = .FALSE.
     ENDIF
+#endif
 
     ! Log output
     IF ( HCO_IsVerb(HcoState%Config%Err,1) ) THEN


### PR DESCRIPTION
This was causing layout regression failures

### Name and Institution (Required)

Name: Atanas  Trayanov
Institution: NASA GSFC

### Confirm you have reviewed the following documentation

- [x ] [Contributing guidelines](https://hemco.readthedocs.io/en/stable/reference/CONTRIBUTING.html)

### Describe the update
A local reduction (sum) was used to determine if a variablle has been filled for a restart. For MODEL_GEOS this lead to a layout regression failure 

Please provide a clear and concise overview of the update.

### Expected changes

Please provide details on how this update will impact model output and include plots or tables as needed.

### Reference(s)

If this is a science update, please provide a literature citation.

### Related Github Issue(s)

Please link to the corresponding Github issue here. If fixing a bug, there should be an issue describing it with steps to reproduce.
